### PR TITLE
add @rpath to library install_name

### DIFF
--- a/SConstruct_common.scons
+++ b/SConstruct_common.scons
@@ -166,8 +166,11 @@ if baseEnv['PLATFORM'] == "posix":
 #    baseEnv.AppendUnique(LINKFLAGS = "-pg")
     baseEnv.AppendUnique(CPPDEFINES = ['TRAP_FPE'])
 
-if baseEnv['PLATFORM'] == "darwin":
-    baseEnv.AppendUnique(SHLINKFLAGS = ["-Wl,-install_name", "-Wl,${TARGET.file}"])
+# if baseEnv['PLATFORM'] == "darwin":
+#     baseEnv.AppendUnique(SHLINKFLAGS = ["-Wl,-install_name,${TARGET.file}"])
+
+if(baseEnv.GetOption('CONDA-EXT')):
+    baseEnv.AppendUnique(SHLINKFLAGS = ["-Wl,-install_name,@rpath/fermitools/${TARGET.file}"])
 
 #########################
 #  Project Environment  #


### PR DESCRIPTION
This change adds the prefix string `@rpath/fermitools/` to every compiled library's "install_name" at build time for packages build for conda targets.